### PR TITLE
利用者から報告されたバグの解消

### DIFF
--- a/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/excel/poi/eventmodel/HSSFSheetLoaderWithPoiEventApi.java
+++ b/xyz.hotchpotch.hogandiff/src/main/java/xyz/hotchpotch/hogandiff/excel/poi/eventmodel/HSSFSheetLoaderWithPoiEventApi.java
@@ -443,8 +443,10 @@ public class HSSFSheetLoaderWithPoiEventApi implements SheetLoader {
                     throw new AssertionError("FORMULA");
                 
                 case STRING:
-                    // STRING の場合は後続の STRING レコードがあるはず
-                    throw new AssertionError("STRING");
+                    // 利用者からのレポートによると、このパスに入る場合があるらしい。
+                    // 返すべき適切な fRec のメンバが見当たらないため、nullを返しておく。
+                    // FIXME: [No.4 数式サポート改善].xlsファイル形式を理解したうえでちゃんとやる
+                    return null;
                 
                 default:
                     throw new AssertionError("unknown cell type: " + type);


### PR DESCRIPTION
xlsファイル同士の比較において、「実行」ボタン押下後に「STRING」という警告ダイアログが表示されるとのこと。
当該エラーを引き起こすようなファイルが手元に無いため再現不可能だが、ソースコードの該当箇所を特定できたため、エラーを発生させないための修正を実施。
本修正によって AssertionError の発生は回避されるが、正しい値（数式計算結果のキャッシュ値）は取得できておらず、その本来の方法は不明である。この修正は将来に持ち越し。